### PR TITLE
Get and format rules via Essentials

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,8 @@ version = '1.0'
 repositories {
     mavenCentral()
     maven {
-        name = "spigotmc-repo"
-        url = "https://hub.spigotmc.org/nexus/content/repositories/snapshots/"
+        name = "papermc"
+        url = uri("https://repo.papermc.io/repository/maven-public/")
     }
     maven {
         name = "sonatype"

--- a/build.gradle
+++ b/build.gradle
@@ -21,12 +21,17 @@ repositories {
     maven {
         url "https://libraries.minecraft.net"
     }
+    maven {
+        name = "essentialsxReleases"
+        url = uri("https://repo.essentialsx.net/releases")
+    }
 }
 
 dependencies {
     compileOnly "org.spigotmc:spigot-api:1.20.4-R0.1-SNAPSHOT"
     compileOnly 'com.mojang:brigadier:1.0.18'
     implementation 'com.github.LeonMangler:SuperVanish:6.2.19'
+    implementation("net.essentialsx:EssentialsX:2.19.0")
 }
 
 def targetJavaVersion = 17

--- a/src/main/java/org/modernbeta/onboarding/Onboarding.java
+++ b/src/main/java/org/modernbeta/onboarding/Onboarding.java
@@ -49,13 +49,14 @@ public final class Onboarding extends JavaPlugin implements Listener {
         instance = this;
 
         // Require Essentials so we can use it later
-        Plugin ess = this.getServer().getPluginManager().getPlugin("Essentials");
-        if (!(ess instanceof Essentials)) {
+        Plugin essentials =
+            this.getServer().getPluginManager().getPlugin("Essentials");
+        if (!(essentials instanceof Essentials)) {
             this.getLogger().severe("Essentials plugin not found!");
             this.getServer().getPluginManager().disablePlugin(this);
             return;
         } else
-            essentials = (Essentials) ess;
+            this.essentials = (Essentials) essentials;
 
         // Plugin startup logic
         if (!Bukkit.getPluginManager().isPluginEnabled("SuperVanish") && !Bukkit.getPluginManager().isPluginEnabled("PremiumVanish")) {

--- a/src/main/java/org/modernbeta/onboarding/Onboarding.java
+++ b/src/main/java/org/modernbeta/onboarding/Onboarding.java
@@ -42,6 +42,7 @@ public final class Onboarding extends JavaPlugin implements Listener {
     static PotionEffect blindness = new PotionEffect(PotionEffectType.BLINDNESS, PotionEffect.INFINITE_DURATION, 1, true, false, false);
 
     private static Connection connection;
+    private static List<String> rules;
 
     @Override
     public void onEnable() {
@@ -187,7 +188,11 @@ public final class Onboarding extends JavaPlugin implements Listener {
         player.setGameMode(GameMode.ADVENTURE);
         player.addPotionEffect(blindness);
         player.sendTitle(ChatColor.RED + "" + ChatColor.BOLD + "ACCEPT RULES IN CHAT", ChatColor.RED + "Then you can continue.", 10, 160, 10);
-        sendRulesAcceptMessage(player, essentials);
+
+        // Ensure rules are always up-to-date for new players
+        reloadRules(essentials);
+
+        sendRulesAcceptMessage(player);
     }
 
     public void acceptOnboardingProcess(Player player) {
@@ -213,14 +218,10 @@ public final class Onboarding extends JavaPlugin implements Listener {
             player.setGameMode(GameMode.SURVIVAL);
     }
 
-    static void sendRulesAcceptMessage(Player player, Essentials essentials) {
+    static void sendRulesAcceptMessage(Player player) {
         player.sendMessage("\n \n \n \n \n \n \n \n \n \n \n \n \n \n \n \n \n \n");
-        try {
-            final TextInput ruleText =
-                new TextInput(new CommandSource(player), "rules", true, essentials);
-            ruleText.getLines().forEach(player::sendMessage);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+        for(String rule : rules) {
+            player.sendMessage(rule);
         }
         player.sendMessage("\n" + ChatColor.RED + "Enter " + ChatColor.BOLD + "/accept" + ChatColor.RED + " to agree to these rules.");
     }
@@ -233,10 +234,21 @@ public final class Onboarding extends JavaPlugin implements Listener {
                 for (UUID playerUUID : needToAccept) {
                     Player player = Bukkit.getPlayer(playerUUID);
                     if (player != null) {
-                        sendRulesAcceptMessage(player, essentials);
+                        sendRulesAcceptMessage(player);
                     }
                 }
             }
         }.runTaskTimer(this, 0, 20); // 0 delay, 20 ticks (1 second) period
+    }
+
+    private static void reloadRules(Essentials essentials) {
+        Bukkit.getLogger().info("Reloading rules...");
+        try {
+            final TextInput ruleText =
+                new TextInput(new CommandSource(Bukkit.getServer().getConsoleSender()), "rules", true, essentials);
+            rules = ruleText.getLines();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/main/java/org/modernbeta/onboarding/Onboarding.java
+++ b/src/main/java/org/modernbeta/onboarding/Onboarding.java
@@ -53,6 +53,7 @@ public final class Onboarding extends JavaPlugin implements Listener {
         if (!(ess instanceof Essentials)) {
             this.getLogger().severe("Essentials plugin not found!");
             this.getServer().getPluginManager().disablePlugin(this);
+            return;
         } else
             essentials = (Essentials) ess;
 

--- a/src/main/java/org/modernbeta/onboarding/Onboarding.java
+++ b/src/main/java/org/modernbeta/onboarding/Onboarding.java
@@ -1,6 +1,8 @@
 package org.modernbeta.onboarding;
 
+import com.earth2me.essentials.CommandSource;
 import com.earth2me.essentials.Essentials;
+import com.earth2me.essentials.textreader.TextInput;
 import de.myzelyam.api.vanish.VanishAPI;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -21,6 +23,7 @@ import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.modernbeta.onboarding.commands.AcceptCommand;
 
+import java.io.IOException;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -184,7 +187,7 @@ public final class Onboarding extends JavaPlugin implements Listener {
         player.setGameMode(GameMode.ADVENTURE);
         player.addPotionEffect(blindness);
         player.sendTitle(ChatColor.RED + "" + ChatColor.BOLD + "ACCEPT RULES IN CHAT", ChatColor.RED + "Then you can continue.", 10, 160, 10);
-        sendRulesAcceptMessage(player);
+        sendRulesAcceptMessage(player, essentials);
     }
 
     public void acceptOnboardingProcess(Player player) {
@@ -210,18 +213,15 @@ public final class Onboarding extends JavaPlugin implements Listener {
             player.setGameMode(GameMode.SURVIVAL);
     }
 
-    static void sendRulesAcceptMessage(Player player) {
+    static void sendRulesAcceptMessage(Player player, Essentials essentials) {
         player.sendMessage("\n \n \n \n \n \n \n \n \n \n \n \n \n \n \n \n \n \n");
-        player.sendMessage(ChatColor.RED + "" + ChatColor.BOLD + "✖ NO " + ChatColor.RESET + "hacking or xraying");
-        player.sendMessage(ChatColor.RED + "" + ChatColor.BOLD + "✖ NO " + ChatColor.RESET + "destroying other's homes/things (griefing)");
-        player.sendMessage(ChatColor.RED + "" + ChatColor.BOLD + "✖ NO " + ChatColor.RESET + "building above other on-land builds w/o permission");
-        player.sendMessage(ChatColor.RED + "" + ChatColor.BOLD + "✖ NO " + ChatColor.RESET + "stealing from chests that aren't marked as public");
-        player.sendMessage(ChatColor.RED + "" + ChatColor.BOLD + "✖ NO " + ChatColor.RESET + "languages besides english in global chats");
-        player.sendMessage(ChatColor.RED + "" + ChatColor.BOLD + "✖ NO " + ChatColor.RESET + "abusing exploits (except sand/gravel piston dupes)");
-        player.sendMessage(ChatColor.RED + "" + ChatColor.BOLD + "✖ NO " + ChatColor.RESET + "sexual, racist, sexist or homophobic content");
-        player.sendMessage(ChatColor.RED + "" + ChatColor.BOLD + "✖ NO " + ChatColor.RESET + "war/political/(real)religious conversations/imagery");
-        player.sendMessage(ChatColor.GREEN + "" + ChatColor.BOLD + "✔ DO " + ChatColor.RESET + "keep real life at the door and enjoy block game ❤");
-        player.sendMessage(ChatColor.GREEN + "" + ChatColor.BOLD + "✔ DO " + ChatColor.RESET + "use common sense and make some friends!");
+        try {
+            final TextInput ruleText =
+                new TextInput(new CommandSource(player), "rules", true, essentials);
+            ruleText.getLines().forEach(player::sendMessage);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
         player.sendMessage("\n" + ChatColor.RED + "Enter " + ChatColor.BOLD + "/accept" + ChatColor.RED + " to agree to these rules.");
     }
 
@@ -233,7 +233,7 @@ public final class Onboarding extends JavaPlugin implements Listener {
                 for (UUID playerUUID : needToAccept) {
                     Player player = Bukkit.getPlayer(playerUUID);
                     if (player != null) {
-                        sendRulesAcceptMessage(player);
+                        sendRulesAcceptMessage(player, essentials);
                     }
                 }
             }

--- a/src/main/java/org/modernbeta/onboarding/Onboarding.java
+++ b/src/main/java/org/modernbeta/onboarding/Onboarding.java
@@ -1,5 +1,6 @@
 package org.modernbeta.onboarding;
 
+import com.earth2me.essentials.Essentials;
 import de.myzelyam.api.vanish.VanishAPI;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -13,6 +14,7 @@ import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -31,6 +33,7 @@ import java.util.UUID;
 public final class Onboarding extends JavaPlugin implements Listener {
 
     public static Onboarding instance;
+    Essentials essentials;
 
     public static List<UUID> needToAccept = new ArrayList<>();
     static PotionEffect blindness = new PotionEffect(PotionEffectType.BLINDNESS, PotionEffect.INFINITE_DURATION, 1, true, false, false);
@@ -40,6 +43,14 @@ public final class Onboarding extends JavaPlugin implements Listener {
     @Override
     public void onEnable() {
         instance = this;
+
+        // Require Essentials so we can use it later
+        Plugin ess = this.getServer().getPluginManager().getPlugin("Essentials");
+        if (!(ess instanceof Essentials)) {
+            this.getLogger().severe("Essentials plugin not found!");
+            this.getServer().getPluginManager().disablePlugin(this);
+        } else
+            essentials = (Essentials) ess;
 
         // Plugin startup logic
         if (!Bukkit.getPluginManager().isPluginEnabled("SuperVanish") && !Bukkit.getPluginManager().isPluginEnabled("PremiumVanish")) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,6 +5,7 @@ api-version: '1.20'
 folia-supported: true
 depend:
   - SuperVanish
+  - Essentials
 commands:
   accept:
     description: Accepts the rules for an onboarding player


### PR DESCRIPTION
Noticed that the rules were in a different order than the server’s `/rules`, figured this would streamline updating rules should it be needed in the future.

Using the Essentials API does possibly overcomplicate it a bit, but I figure it’s more robust than manually finding path to, reading, then formatting the Essentials rules file.

⚠️ This also included a change to move the Spigot dependencies to the Paper repository because Essentials’ API itself has some dependencies in `io.papermc`. The plugin itself still builds against the same Spigot API though, just from the Paper Maven repo.

~~Marked as a draft since I want to quickly implement caching the rules — right now it reloads the rules from disk every second during onboarding spam.~~ Added in [4563bde](https://github.com/ModernBetaNetwork/Onboarding/pull/1/commits/4563bde1beab3718d85acc02eff0f139aaeea9de)