### PR TITLE
Added a deny command and simplified the onEnable function

### DIFF
--- a/src/main/java/org/modernbeta/onboarding/Onboarding.java
+++ b/src/main/java/org/modernbeta/onboarding/Onboarding.java
@@ -55,7 +55,7 @@ public final class Onboarding extends JavaPlugin implements Listener {
         // Register events and commands
         Bukkit.getPluginManager().registerEvents(this, this);
 
-        // Register commands - simplified without null checks
+        // Register commands
         getCommand("accept").setExecutor(new AcceptCommand());
         getCommand("deny").setExecutor(new DenyCommand());
 

--- a/src/main/java/org/modernbeta/onboarding/Onboarding.java
+++ b/src/main/java/org/modernbeta/onboarding/Onboarding.java
@@ -22,6 +22,7 @@ import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.modernbeta.onboarding.commands.AcceptCommand;
+import org.modernbeta.onboarding.commands.DenyCommand;
 
 import java.io.IOException;
 import java.sql.Connection;
@@ -48,26 +49,15 @@ public final class Onboarding extends JavaPlugin implements Listener {
     public void onEnable() {
         instance = this;
 
-        // Require Essentials so we can use it later
-        Plugin essentials =
-            this.getServer().getPluginManager().getPlugin("Essentials");
-        if (!(essentials instanceof Essentials)) {
-            this.getLogger().severe("Essentials plugin not found!");
-            this.getServer().getPluginManager().disablePlugin(this);
-            return;
-        } else
-            this.essentials = (Essentials) essentials;
+        // Get Essentials plugin instance
+        this.essentials = (Essentials) Bukkit.getPluginManager().getPlugin("Essentials");
 
-        // Plugin startup logic
-        if (!Bukkit.getPluginManager().isPluginEnabled("SuperVanish") && !Bukkit.getPluginManager().isPluginEnabled("PremiumVanish")) {
-            Bukkit.getLogger().warning("Super/Premium Vanish not installed, disabling.");
-            Bukkit.getPluginManager().disablePlugin(this);
-            return;
-        }
-
+        // Register events and commands
         Bukkit.getPluginManager().registerEvents(this, this);
-        PluginCommand acceptCommand = getCommand("accept");
-        if (acceptCommand != null) acceptCommand.setExecutor(new AcceptCommand());
+
+        // Register commands - simplified without null checks
+        getCommand("accept").setExecutor(new AcceptCommand());
+        getCommand("deny").setExecutor(new DenyCommand());
 
         setupDatabase();
         spamRules();
@@ -189,7 +179,7 @@ public final class Onboarding extends JavaPlugin implements Listener {
         VanishAPI.getPlugin().getVisibilityChanger().hidePlayer(player, player.getName(), true);
         player.setGameMode(GameMode.ADVENTURE);
         player.addPotionEffect(blindness);
-        player.sendTitle(ChatColor.RED + "" + ChatColor.BOLD + "ACCEPT RULES IN CHAT", ChatColor.RED + "Then you can continue.", 10, 160, 10);
+        player.sendTitle(ChatColor.RED + "" + ChatColor.BOLD + "ACCEPT OR DENY RULES", ChatColor.RED + "Type /accept to play or /deny to leave.", 10, 160, 10);
 
         // Ensure rules are always up-to-date for new players
         reloadRules(essentials);
@@ -226,6 +216,7 @@ public final class Onboarding extends JavaPlugin implements Listener {
             player.sendMessage(rule);
         }
         player.sendMessage("\n" + ChatColor.RED + "Enter " + ChatColor.BOLD + "/accept" + ChatColor.RED + " to agree to these rules.");
+        player.sendMessage(ChatColor.RED + "Or enter " + ChatColor.BOLD + "/deny" + ChatColor.RED + " if you do not agree (this will kick you from the server).");
     }
 
     private void spamRules() {

--- a/src/main/java/org/modernbeta/onboarding/commands/DenyCommand.java
+++ b/src/main/java/org/modernbeta/onboarding/commands/DenyCommand.java
@@ -1,0 +1,28 @@
+package org.modernbeta.onboarding.commands;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.modernbeta.onboarding.Onboarding;
+
+public class DenyCommand implements CommandExecutor
+{
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args)
+    {
+        if (!(sender instanceof Player senderPlayer)) {
+            sender.sendMessage("This command can only be performed by a real player.");
+            return false;
+        }
+
+        if (!Onboarding.needToAccept.contains(senderPlayer.getUniqueId())) {
+            sender.sendMessage("You have already accepted the rules or don't need to accept them.");
+            return true;
+        }
+
+        // Kick the player with a message
+        senderPlayer.kickPlayer("You must accept the rules to play on this server. Please rejoin and type /accept when ready.");
+        return true;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -13,3 +13,9 @@ commands:
     aliases:
       - agree
       - yes
+  deny:
+    description: Denies the rules and kicks the player from the server
+    usage: /deny
+    aliases:
+      - disagree
+      - no


### PR DESCRIPTION
Simplify onEnable by removing redundant dependency checks. Since plugin.yml already handles dependencies, we don't need additional runtime checks for Essentials and SuperVanish

I have also added a deny command to allow players to deny the rules if denied it will just simply kick them and they can rejoin and try again 